### PR TITLE
Add Simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,25 +10,6 @@
 /test/version_tmp/
 /tmp/
 
-# Used by dotenv library to load environment variables.
-# .env
-
-## Specific to RubyMotion:
-.dat*
-.repl_history
-build/
-*.bridgesupport
-build-iPhoneOS/
-build-iPhoneSimulator/
-
-## Specific to RubyMotion (use of CocoaPods):
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# vendor/Pods/
-
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/
@@ -42,9 +23,11 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# ignore test output
+.rspec_status
+coverage

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/sagas.gemspec
+++ b/sagas.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.4'
 
+  s.add_development_dependency "simplecov"
   s.add_development_dependency "bundler", "~> 1.16"
   s.add_development_dependency "rake", "~> 12.3"
   s.add_development_dependency "rspec", "~> 3.8"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require_relative "../lib/sagas"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Simplecov is called before the test suite is run (e.g. if you type `rspec` to run tests in the repo) and then generates a report like this one:
<img width="1437" alt="screen shot 2018-12-20 at 5 59 51 pm" src="https://user-images.githubusercontent.com/22259826/50315553-3d76d100-0481-11e9-8f62-305b50db9972.png">


Todo after this:
Run simplecov with CI builds and update codeclimate with the result
Looks fairly easy: https://docs.codeclimate.com/v1.0/docs/travis-ci-test-coverage